### PR TITLE
Add support for password authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,5 @@ Environment Variables
 `ANNOUNCE_PORT` - Mapped sentinel port.
 
 `AWS_IP_DISCOVERY` - Use internal IP address of AWS EC2 machine as `ANNOUNCE_IP`.
+
+`AUTH_PASS` - Authentication password to use when connecting to master.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -69,6 +69,10 @@ if [ "$MASTER_NAME" ]; then
       echo "sentinel client-reconfig-script $MASTER_NAME $CLIENT_RECONFIG_SCRIPT" >> $SENTINEL_CONFIGURATION_FILE
     fi
 
+    if [ "$AUTH_PASS" ]; then
+      echo "sentinel auth-pass $MASTER_NAME $AUTH_PASS" >> $SENTINEL_CONFIGURATION_FILE
+    fi
+
     if [ "$SLAVES" ]; then
         for SLAVE in $(echo $SLAVES | tr ";" "\n")
         do


### PR DESCRIPTION
Support [Redis master password authentication](https://redis.io/topics/sentinel#sentinel-and-redis-authentication) by handling (the optional) `AUTH_PASS` environment variable.