### PR TITLE
Updated Compose file version to 3.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 services:
     redis_master:


### PR DESCRIPTION
I'm playing around with this in Docker Swarm.  It doesn't like the Compose version 2 format.

```
$ docker stack deploy -c docker-compose.yml redisha02
unsupported Compose file version: 2
```